### PR TITLE
1.0.17 - Fallback when passed transition arguments on unsupported model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "cfg-if"
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "system76-firmware"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "buildchain",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-firmware"
-version = "1.0.16"
+version = "1.0.17"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2018"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-firmware (1.0.17) focal; urgency=medium
+
+  * Fallback when passed transition arguments on unsupported model
+
+ -- Jeremy Soller <jeremy@system76.com>  Fri, 18 Sep 2020 10:05:32 -0600
+
 system76-firmware (1.0.16) focal; urgency=medium
 
   * Support for transitioning to open firmware

--- a/examples/firmware_id.rs
+++ b/examples/firmware_id.rs
@@ -22,10 +22,16 @@ fn inner() -> Result<(), String> {
         TransitionKind::Proprietary
     ] {
         println!("{:?}", transition_kind);
-        let (transition_model, transition_ec) = transition_kind.transition(&bios_model, variant, &ec_project);
-        println!("  Model: {}", transition_model);
-        println!("  Project: {}", transition_ec);
-        println!("  Firmware ID: {}", generate_firmware_id(&transition_model, &transition_ec));
+        match transition_kind.transition(&bios_model, variant, &ec_project) {
+            Ok((transition_model, transition_ec)) => {
+                println!("  Model: {}", transition_model);
+                println!("  Project: {}", transition_ec);
+                println!("  Firmware ID: {}", generate_firmware_id(&transition_model, &transition_ec));
+            },
+            Err(err) => {
+                println!("  Error: {}", err);
+            }
+        }
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub fn firmware_id(transition_kind: TransitionKind) -> Result<String, String> {
     let (bios_model, _bios_version) = bios::bios()?;
     let variant = model_variant(&bios_model)?;
     let (ec_project, _ec_version) = ec_or_none(true);
-    let (transition_model, transition_ec) = transition_kind.transition(&bios_model, variant, &ec_project);
+    let (transition_model, transition_ec) = transition_kind.transition(&bios_model, variant, &ec_project)?;
     Ok(generate_firmware_id(&transition_model, &transition_ec))
 }
 

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -1,3 +1,4 @@
+// Make sure this is up to date with support article
 static TRANSITIONS: &'static [Transition] = &[
     Transition::new("addw2", "PBx0Dx2", false),
     Transition::new("darp6", "N150CU", true),
@@ -51,7 +52,7 @@ pub enum TransitionKind {
 }
 
 impl TransitionKind {
-    pub fn transition(self, model: &str, variant: u8, project: &str) -> (String, String) {
+    pub fn transition(self, model: &str, variant: u8, project: &str) -> Result<(String, String), String> {
         for transition in TRANSITIONS.iter() {
             if model == transition.model && variant == transition.variant {
                 let new_project = if project == transition.open {
@@ -74,10 +75,20 @@ impl TransitionKind {
                     project
                 };
 
-                return (model.to_string(), new_project.to_string());
+                return Ok((model.to_string(), new_project.to_string()));
             }
         }
 
-        (model.to_string(), project.to_string())
+        // Fallback in case transition is not defined
+        match self {
+            TransitionKind::Open if project != "76ec" => {
+                Err(format!("Model '{}' is not supported by open firmware and EC at this time", model))
+            },
+            TransitionKind::Proprietary if project == "76ec" => {
+                Err(format!("Model '{}' is not supported by proprietary firmware and EC at this time", model))
+            },
+            _ => Ok((model.to_string(), project.to_string())),
+        }
+
     }
 }


### PR DESCRIPTION
This will print an error message when unsupported firmware is selected, as opposed to simply reflashing the current firmware.

In the event of no transition being defined:
- If no argument is passed, it will update the current firmware variant.
- If --open is passed, it will require the system to be running System76 EC, or will print an error
- If --proprietary is passed, it will require the system to not be running System76 EC, or it will print an error