### PR TITLE
1.0.19 - Re-enable darp6 automatic transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "system76-firmware"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "buildchain",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-firmware"
-version = "1.0.18"
+version = "1.0.19"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2018"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-firmware (1.0.19) focal; urgency=medium
+
+  * Re-enable darp6 automatic transition
+
+ -- Jeremy Soller <jeremy@system76.com>  Thu, 24 Sep 2020 09:36:57 -0600
+
 system76-firmware (1.0.18) focal; urgency=medium
 
   * Fix CLI argument parsing of --proprietary

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -1,7 +1,7 @@
 // Make sure this is up to date with support article
 static TRANSITIONS: &'static [Transition] = &[
     Transition::new("addw2", "PBx0Dx2", false),
-    Transition::new("darp6", "N150CU", false), // TODO: set liberate to true
+    Transition::new("darp6", "N150CU", true),
     // 17-inch 1660Ti
     Transition::new_variant("gaze15", 0, "NH5xDC", false),
     // 15-inch 1660Ti


### PR DESCRIPTION
When https://github.com/system76/firmware-open/issues/130 is deemed successful, this will re-enable the darp6 automatic transition to open EC

Rebase and tag when approved