### PR TITLE
Add /efi mount point for newer Arch/SystemD setups

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,7 @@ pub fn get_efi_mnt() -> Option<String> {
         [
             path::Path::new("/boot"),
             path::Path::new("/boot/efi"),
+            path::Path::new("/efi"),
         ].iter()
          .find(|x| x.join(efi).as_path().is_dir())
          .and_then(|x| x.to_str().map(String::from))


### PR DESCRIPTION
Recent Arch Linux installs may sometimes use `/efi` as the EFI boot directory

- https://wiki.archlinux.org/index.php/EFI_system_partition#Typical_mount_points
- https://github.com/systemd/systemd/pull/3757#issuecomment-234290236