### PR TITLE
fix: Create cache directory if it doesn't exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,11 @@ pub fn download_firmware_id(firmware_id: &str) -> Result<(String, String), Strin
         Some(config::CERT)
     )?;
 
+    if !fs::metadata(config::CACHE).is_ok() {
+       eprintln!("creating cache directory {}", config::CACHE);
+       fs::create_dir(config::CACHE).map_err(err_str)?;
+    }
+
     eprintln!("downloading tail");
 
     let tail_cache = Path::new(config::CACHE).join("tail");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub fn download_firmware_id(firmware_id: &str) -> Result<(String, String), Strin
         Some(config::CERT)
     )?;
 
-    if !fs::metadata(config::CACHE).is_ok() {
+    if !Path::new(config::CACHE).is_dir() {
        eprintln!("creating cache directory {}", config::CACHE);
        fs::create_dir(config::CACHE).map_err(err_str)?;
     }


### PR DESCRIPTION
Fixes https://github.com/pop-os/system76-firmware/issues/54.

Tested on an affected installation (can be recreated by removing `/var/cache/system76-firmware-daemon`), also tested in a live disk. Tested on both 20.10 and 20.04. When running the `system76-firmware-cli schedule` command from the CLI, an extra line is output when the cache directory is created:

![Screenshot from 2021-04-30 22-32-19](https://user-images.githubusercontent.com/7199422/116760278-c9924f00-a9d1-11eb-830e-15504cb95197.png)

On subsequent runs, the directory already exists, so the line is not printed.