### PR TITLE
system76-firmware: add missing dependency on efibootmgr

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Homepage: https://github.com/pop-os/system76-firmware
 Package: system76-firmware
 Architecture: amd64
 Depends:
+  efibootmgr,
   ${misc:Depends},
   ${shlib:Depends}
 Description: System76 Firmware CLI


### PR DESCRIPTION
Without efibootmgr installed, an attempt to schedule a firmware upgrade
to the next boot fails with:

"efibootmgr" "--quiet" "--delete-bootnext"
system76-firmware: failed to schedule: failed to unset next boot: No such file or directory (os error 2)