### PR TITLE
Specify tar version 0.4.35 to work around regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "libdbus-sys"
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "system76-firmware"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.37"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
 dependencies = [
  "filetime",
  "libc",
@@ -1815,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-firmware"
-version = "1.0.30"
+version = "1.0.31"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ rust-lzma = "0.5"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
-tar = "0.4"
+tar = "=0.4.35"
 tempdir = "0.3"
 uuid = "0.8"
 bincode = "1.3"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-firmware (1.0.31) focal; urgency=medium
+
+  * Specify tar version 0.4.35 to work around regression
+
+ -- Jacob Kauffmann <jacob@system76.com>  Tue, 17 Sep 2021 10:26:00 -0600
+
 system76-firmware (1.0.30) focal; urgency=medium
 
   * Fix updating tail cache


### PR DESCRIPTION
Fixes https://github.com/pop-os/system76-firmware/issues/70.

Ideally, we'll want to report this upstream or adjust our code to work with the newer version, but in the meantime, this will allow firmware updates to work.