### PR TITLE
Add thelio-mira-b3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "system76-firmware"
-version = "1.0.35"
+version = "1.0.36"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-firmware"
-version = "1.0.35"
+version = "1.0.36"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2018"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-firmware (1.0.36) jammy; urgency=medium
+
+  * Add thelio-mira-b3
+
+ -- Levi Portenier <levi@system76.com>  Fri, 06 May 2022 16:11:18 -0600
+
 system76-firmware (1.0.35) jammy; urgency=medium
 
   * Add thelio-mira-b2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ const MODEL_WHITELIST: &[&str] = &[
     "thelio-mega-r1.1",
     "thelio-mira-b1",
     "thelio-mira-b2",
+    "thelio-mira-b3",
     "thelio-mira-r1",
     "thelio-r1",
     "thelio-r2",


### PR DESCRIPTION
Based off of the `mira-b2` branch to make the debian/changelog easier