### PR TITLE
Make date and description required fields

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -194,11 +194,11 @@ pub struct Version {
     pub bios_me: bool,
     pub bios_set: bool,
     pub bios: Box<str>,
-    pub description: Option<Box<str>>,
+    pub description: Box<str>,
     pub me_cr: bool,
     pub me_hap: bool,
     pub me: Option<Box<str>>,
-    pub date: Option<Box<str>>,
+    pub date: Box<str>,
 }
 
 /// Signature of the firmware that can be installed on the system.


### PR DESCRIPTION
10e1ad5f141d was a stopgap to ensure nothing would break when adding the date field to the JSON changelogs. Now that all releases have a release date, make it required.

Also make description a required field.

Requires: system76/firmware#430