### PR TITLE
schedule: create temp dir within EFI dir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,8 @@ pub fn schedule_firmware_id(digest: &str, efi_dir: &str, firmware_id: &str) -> R
 
     remove_dir(&updater_dir)?;
 
-    let updater_tmp = match tempfile::TempDir::with_prefix_in(efi_dir, "system76-firmware-update") {
+    let prefix = format!("{}/", efi_dir);
+    let updater_tmp = match tempfile::TempDir::with_prefix_in(prefix, "system76-firmware-update") {
         Ok(ok) => ok,
         Err(err) => {
             return Err(format!("failed to create temporary directory: {}", err));


### PR DESCRIPTION
I saw the following during an upgrade attempt:
moving /boot/efigMxXdR to /boot/efi/system76-firmware-update
removing /boot/efigMxXdR
system76-firmware: failed to schedule: failed to move /boot/efigMxXdR to /boot/efi/system76-firmware-update: Invalid cross-device link (os error 18)

This appears to be related to moving across file systems; /boot/efi is the ESP,
whereas /boot/efiXXXXX is on the root fs, which is ext4.
To avoid the cross fs move, simply create the temp dir within the EFI dir.

Signed-off-by: Daniel Maslowski <info@orangecms.org>
