### PR TITLE
Fix argument order for `with_prefix_in`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ pub fn schedule_firmware_id(digest: &str, efi_dir: &str, firmware_id: &str) -> R
 
     remove_dir(&updater_dir)?;
 
-    let updater_tmp = match tempfile::TempDir::with_prefix_in(efi_dir, "system76-firmware-update") {
+    let updater_tmp = match tempfile::TempDir::with_prefix_in("system76-firmware-update.", efi_dir) {
         Ok(ok) => ok,
         Err(err) => {
             return Err(format!("failed to create temporary directory: {}", err));


### PR DESCRIPTION
The argument order is wrong, causing upgrades to fail when moving the temp extract to the EFI partition.

    system76-firmware: failed to schedule: failed to move /boot/efiMG6RBk to /efi/boot/system76-firmware-update: Invalid cross-device link (os error 18)

Additionally, add a `.` as a separator to the prefix to exactly match the old tempdir behavior, as tempfile does not add a separator itself.

Fixes: 4613ff0badba ("Update edition, deps, toolchain")
Ref: [`tempfile::TempDir#with_prefix_in`](https://docs.rs/tempfile/3.8.0/tempfile/struct.TempDir.html#method.with_prefix_in)
Resolves: #120