### PR TITLE
Remove `bios_set` and `bios_me`

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -191,14 +191,12 @@ pub struct Changelog {
 /// Details about a version of firmware.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Version {
-    pub bios_me: bool,
-    pub bios_set: bool,
+    pub date: Box<str>,
     pub bios: Box<str>,
     pub description: Box<str>,
     pub me_cr: Option<bool>,
     pub me_hap: Option<bool>,
     pub me: Option<Box<str>>,
-    pub date: Box<str>,
 }
 
 /// Signature of the firmware that can be installed on the system.


### PR DESCRIPTION
- `bios_set` is an unused value and will be removed
- `bios_me` provides no validation and will be removed

Neither of these fields are used by firmware-manager.

Ref: https://github.com/system76/firmware/pull/600