### PR TITLE
Remove `me_cr` and `me_hap`

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -193,10 +193,8 @@ pub struct Changelog {
 pub struct Version {
     pub date: Box<str>,
     pub bios: Box<str>,
-    pub description: Box<str>,
-    pub me_cr: Option<bool>,
-    pub me_hap: Option<bool>,
     pub me: Option<Box<str>>,
+    pub description: Box<str>,
 }
 
 /// Signature of the firmware that can be installed on the system.


### PR DESCRIPTION
These fields were used in the private firmware repo as part of reporting CSME information. Neither of these fields are used by firmware-manager.

See also: #123