### PR TITLE
Use libc::Ioctl for ioctl constant

### DIFF
--- a/src/me.rs
+++ b/src/me.rs
@@ -53,7 +53,7 @@ pub fn me() -> Result<Option<String>, String> {
             uuid_bytes[8..].copy_from_slice(bytes);
         }
 
-        if unsafe { libc::ioctl(mei_fd, 0xc0104801, uuid_bytes.as_mut_ptr()) } != 0 {
+        if unsafe { libc::ioctl(mei_fd, 0xc0104801u32 as libc::Ioctl, uuid_bytes.as_mut_ptr()) } != 0 {
             return Err(format!(
                 "failed to send MEI UUID: {}",
                 io::Error::last_os_error()


### PR DESCRIPTION
Unfortunately musl uses int and glibc uses unsigned long for the ioctl request. The actual kernel sees it as a packed 32 bit value.

The libc crate tests that the symbols it exports have the same signature as the underlying libc. It at least export a Ioctl type that we can use to compile against both glibc and musl without too much pain.