### PR TITLE
Upgrade libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "f0b21006cd1874ae9e650973c565615676dc4a274c965bb0a73796dac838ce4f"
 
 [[package]]
 name = "libdbus-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bincode = "1.3"
 buildchain = "0.5"
 clap = { version = "3", features = ["derive"] }
 ecflash = { git = "https://github.com/system76/ecflash.git", branch = "stable" }
-libc = "0.2"
+libc = "0.2.160"
 plain = "0.2"
 rust-lzma = "0.6"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This fixes the build on alpine linux, which uses musl libc.