### PR TITLE
Update ecflash to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,14 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecflash"
-version = "0.1.0"
-source = "git+https://github.com/system76/ecflash.git?branch=stable#ee9d69d4edf3bee6b2fb6dddb021bb58ee3bbbbb"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,12 +760,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1386,13 +1372,13 @@ dependencies = [
  "bincode",
  "buildchain",
  "clap",
- "ecflash",
  "libc",
  "plain",
  "rust-lzma",
  "serde",
  "serde_json",
  "sha2",
+ "system76_ecflash",
  "system76_ectool",
  "tar",
  "tempfile",
@@ -1413,6 +1399,12 @@ dependencies = [
  "system76-firmware",
  "thiserror",
 ]
+
+[[package]]
+name = "system76_ecflash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4428b459c1c06e7a3ecf1dd3e863f4e7442a474463094af6a702e3b860ec25"
 
 [[package]]
 name = "system76_ectool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,17 @@ anyhow = "1.0"
 bincode = "1.3"
 buildchain = "0.5.3"
 clap = { version = "3", features = ["derive"] }
-ecflash = { git = "https://github.com/system76/ecflash.git", branch = "stable" }
 libc = "0.2"
 plain = "0.2"
 rust-lzma = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+system76_ecflash = "0.1.3"
+system76_ectool = { version = "0.2.1", features = ["std"] }
 tar = "0.4"
 tempfile = "3.20"
 uuid = "1.17"
-
-[dependencies.system76_ectool]
-version = "0.2.1"
-features = ["std"]
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod util;
 
 mod bios;
 mod boot;
+#[cfg(target_arch = "x86_64")]
 mod ec;
 mod me;
 mod mount;
@@ -20,6 +21,7 @@ mod thelio_io;
 mod transition;
 
 pub use crate::bios::bios;
+#[cfg(target_arch = "x86_64")]
 pub use crate::ec::{ec, ec_or_none};
 pub use crate::me::me;
 pub use crate::thelio_io::{
@@ -210,7 +212,11 @@ pub fn generate_firmware_id(model: &str, project: &str) -> String {
 pub fn firmware_id(transition_kind: TransitionKind) -> Result<String, String> {
     let (bios_model, _bios_version) = bios::bios()?;
     let variant = model_variant(&bios_model)?;
-    let (ec_project, _ec_version) = ec_or_none(true);
+    let (ec_project, _ec_version) = if cfg!(target_arch = "x86_64") {
+        ec_or_none(true)
+    } else {
+        ("none".to_owned(), "".to_owned())
+    };
     let (transition_model, transition_ec) =
         transition_kind.transition(&bios_model, variant, &ec_project)?;
     Ok(generate_firmware_id(&transition_model, &transition_ec))


### PR DESCRIPTION
`stable` branch was unmaintained and was deleted at some point. `master` builds with a stable toolchain since 0.1.3, when `asm` was stabilized.

Resolves: #154 


### Test

- flashing proprietary EC still works with change from file IO to port IO?
  - or is it just used for detection/reporting?