### PR TITLE
adds nix-shell to build system76-firmware-cli package

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs; [
+       cargo
+       dbus
+       gnumake
+       pkg-config
+       openssl
+       rustc
+       xz
+       ];
+    shellHook = ''
+       export RUST_BACKTRACE=1;
+    '';
+}


### PR DESCRIPTION
This PR adds a nix-shell file which when `nix-shell` is ran in this repository (with nix installed) will install the needed packages to build the project with `make all`.