### PR TITLE
fix: ubuntu build requires specifying the version of rust package(s)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,10 @@ name = "system76-firmware"
 version = "1.0.70"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2021"
+rust-version = "1.80"
 
 [workspace]
-members = [ "daemon" ]
+members = ["daemon"]
 
 [[bin]]
 name = "system76-firmware-cli"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ includedir = $(prefix)/include
 datarootdir = $(prefix)/share
 datadir = $(datarootdir)
 
+CARGO_BIN ?= cargo
 SRC = Cargo.toml Cargo.lock Makefile $(shell find src -type f -wholename '*src/*.rs')
 
 .PHONY: all clean distclean install uninstall update
@@ -24,7 +25,7 @@ endif
 all: target/release/$(CLI) target/release/$(DAEMON)
 
 clean:
-	cargo clean
+	$(CARGO_BIN) clean
 
 distclean: clean
 	rm -rf .cargo vendor vendor.tar.xz
@@ -63,5 +64,5 @@ target/release/$(CLI) target/release/$(DAEMON): $(SRC)
 ifeq ($(VENDORED),1)
 	tar pxf vendor.tar.xz
 endif
-	cargo build $(ARGS)
-	cargo build -p $(DAEMON) $(ARGS)
+	$(CARGO_BIN) build $(ARGS)
+	$(CARGO_BIN) build -p $(DAEMON) $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 all: target/release/$(CLI) target/release/$(DAEMON)
 
 clean:
-	$(CARGO_BIN) clean
+	cargo clean
 
 distclean: clean
 	rm -rf .cargo vendor vendor.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 all: target/release/$(CLI) target/release/$(DAEMON)
 
 clean:
-	cargo clean
+	$(CARGO_BIN) clean
 
 distclean: clean
 	rm -rf .cargo vendor vendor.tar.xz

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: Jeremy Soller <jeremy@system76.com>
 Build-Depends:
   debhelper (>=9.20160709),
   ca-certificates,
-  cargo,
+  cargo-1.80,
+  rustc-1.80,
   libdbus-1-dev,
   liblzma-dev,
   libssl-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export VENDORED ?= 1
+export CARGO_BIN ?= cargo-1.80
 CLEAN ?= 1
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,8 @@
 #!/usr/bin/make -f
 
+RUST_VERSION=$(shell grep rust-version Cargo.toml | awk -F'"' '{print $$2}')
 export VENDORED ?= 1
-export CARGO_BIN ?= cargo-1.80
+export CARGO_BIN ?= cargo-$(RUST_VERSION)
 CLEAN ?= 1
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -2,19 +2,19 @@
 
 RUST_VERSION=$(shell grep rust-version Cargo.toml | awk -F'"' '{print $$2}')
 export VENDORED ?= 1
-export CARGO_BIN ?= cargo-$(RUST_VERSION)
 CLEAN ?= 1
 
 %:
 	dh $@ --with=systemd
 
 override_dh_auto_build:
-	env CARGO_HOME="$$(pwd)/target/cargo" \
-	dh_auto_build
+	env CARGO_BIN="cargo-$(RUST_VERSION)" \
+	   CARGO_HOME="$$(pwd)/target/cargo" \
+	   dh_auto_build
 
 override_dh_auto_clean:
 ifeq ($(CLEAN),1)
-	make clean
+	ischroot && env CARGO_BIN="cargo-$(RUST_VERSION)" make clean || make clean
 endif
 ifeq ($(VENDORED),1)
 	if ! ischroot; then \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.80.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
May fix builds on Launchpad since the `cargo` / `rustc` package defaults to 1.75 in Jammy. They have versioned packages for each version of Rust all the way up to 1.80 currently.