### PR TITLE
Use Rust 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "system76-firmware"
 version = "1.0.76"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 
 [workspace]
 members = ["daemon"]

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Jeremy Soller <jeremy@system76.com>
 Build-Depends:
   debhelper (>=9.20160709),
   ca-certificates,
-  cargo-1.80,
-  rustc-1.80,
+  cargo-1.85,
+  rustc-1.85,
   libdbus-1-dev,
   liblzma-dev,
   libssl-dev,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.85.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Should fix build on 26.04 without requiring a branch. Delete the master_resolute after merging!