### PR TITLE
Add subcommand to determine if system is up-to-date

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1776326782,
+        "narHash": "sha256-QzTHb5vhPVensbkL7+WhemxFYXINcdZB1SQ5EMjG2AU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "47ece0146691d625f10a3d2ec4a2c04fca29a35b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776280158,
+        "narHash": "sha256-0uGgwgFVPQ28cVx7onaB1iTCHGi20MNx54e6KZbYnMs=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "94c2f68935467a6381a4f3504ae6c709b5fd3c61",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,17 @@
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = [
             fenix.packages.${system}.complete.toolchain
+            pkgs.pkg-config
+          ];
+          buildInputs = [
+            pkgs.openssl
+            pkgs.xz
+            pkgs.dbus
+          ];
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.openssl
+            pkgs.xz
+            pkgs.dbus
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      fenix,
+      nixpkgs,
+      utils,
+    }:
+    utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [
+            fenix.packages.${system}.complete.toolchain
+          ];
+        };
+      }
+    );
+}

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -9,6 +9,8 @@ use system76_firmware::*;
     setting = AppSettings::SubcommandRequired
 )]
 enum Args {
+    #[clap(about = "Check if firmware updates are available")]
+    Check,
     #[clap(about = "Schedule installation of firmware for next boot")]
     Schedule {
         #[clap(help = "Schedule install of open firmware", long = "open")]
@@ -26,6 +28,74 @@ enum Args {
     ThelioIo,
 }
 
+// Local deserialization structs for changelog.json.
+// The canonical types live in the daemon crate, which we can't import here
+// without creating a circular dependency.
+#[derive(serde::Deserialize)]
+struct Changelog {
+    versions: Vec<ChangelogVersion>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChangelogVersion {
+    bios: String,
+    me: Option<String>,
+}
+
+fn efi_dir() -> Result<String, String> {
+    util::get_efi_mnt().ok_or_else(|| "EFI mount point not found".into())
+}
+
+fn check() -> Result<bool, String> {
+    let (model, current_bios) = bios()?;
+
+    let current_me = me()?;
+
+    let (_digest, changelog_json) = download(TransitionKind::Automatic)
+        .map_err(|err| format!("failed to download: {}", err))?;
+
+    let changelog: Changelog = serde_json::from_str(&changelog_json)
+        .map_err(|err| format!("failed to parse changelog: {}", err))?;
+
+    let latest = changelog
+        .versions
+        .first()
+        .ok_or_else(|| "changelog has no versions".to_string())?;
+
+    let bios_outdated = current_bios != latest.bios;
+    println!("BIOS:");
+    println!("  Model:     {}", model);
+    println!("  Current:   {}", current_bios);
+    println!("  Available: {}", latest.bios);
+    println!("  {}", if bios_outdated { "Update available" } else { "Up to date" });
+
+    let me_outdated = if let Some(ref current_me) = current_me {
+        println!();
+        println!("ME:");
+        println!("  Current:   {}", current_me);
+        if let Some(ref available_me) = latest.me {
+            let outdated = current_me != available_me;
+            println!("  Available: {}", available_me);
+            println!("  {}", if outdated { "Update available" } else { "Up to date" });
+            outdated
+        } else {
+            println!("  No ME update in changelog");
+            false
+        }
+    } else {
+        false
+    };
+
+    let update_available = bios_outdated || me_outdated;
+
+    if update_available {
+        println!();
+        println!("Firmware update available. Run 'system76-firmware-cli schedule' to install.");
+    }
+
+    Ok(update_available)
+}
+
 fn tool() -> Result<(), String> {
     if unsafe { libc::geteuid() } != 0 {
         return Err("must be run as root".to_string());
@@ -40,13 +110,16 @@ fn tool() -> Result<(), String> {
         ));
     }
 
-    let efi_dir = match util::get_efi_mnt() {
-        Some(x) => x,
-        None => return Err("EFI mount point not found".into()),
-    };
-
     match Args::parse() {
+        Args::Check => {
+            let update_available = check()?;
+            if update_available {
+                process::exit(2);
+            }
+            Ok(())
+        }
         Args::Schedule { open, proprietary } => {
+            let efi_dir = efi_dir()?;
             let transition_kind = if open {
                 TransitionKind::Open
             } else if proprietary {
@@ -65,10 +138,13 @@ fn tool() -> Result<(), String> {
                 Err(err) => Err(format!("failed to schedule: {}", err)),
             }
         }
-        Args::Unschedule => match unschedule(&efi_dir) {
-            Ok(()) => Ok(()),
-            Err(err) => Err(format!("failed to unschedule: {}", err)),
-        },
+        Args::Unschedule => {
+            let efi_dir = efi_dir()?;
+            match unschedule(&efi_dir) {
+                Ok(()) => Ok(()),
+                Err(err) => Err(format!("failed to unschedule: {}", err)),
+            }
+        }
         Args::ThelioIo => {
             let (digest, _revision) = match thelio_io_download() {
                 Ok(ok) => ok,


### PR DESCRIPTION
This should close #76.

Adds a simple cli subcommand `check` for checking if a firmware update is needed. I was trying to add some automation to my nixos config on my system76 laptop and saw this gap in functionality. I was looking at scheduling an update an then backing it out if the versions matched, but it seemed like some unnecessary churn so I figured I would maybe contribute a nice fix to enable this kind of thing for myself and others.

I don't have a machine to check the ME side of things, but I think I did it right.

On my laptop:

```
❯ ./target/debug/system76-firmware-cli check
[sudo] password for jack:
Automatic transition: 76ec -> 76ec
downloading tail
opening download cache
downloading manifest.json
downloading system76-firmware-update.tar.xz
downloading addw4_df60b821b2f5c45288098dba9e084aeb79d491d4133f84b73d298155aba6597e.tar.xz
loading changelog.json
Ok("./changelog.json")
BIOS:
  Model:     addw4
  Current:   2025-07-02_7c6225e
  Available: 2025-07-02_7c6225e
  Up to date
```