### PR TITLE
Add thelio-mira-r6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76-firmware"
-version = "1.0.77"
+version = "1.0.78"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
 edition = "2024"
 rust-version = "1.91"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-firmware (1.0.78) noble; urgency=medium
+
+  * Add thelio-mira-r6
+
+ -- Jonah Grasso <jonah@system76.com>  Thu, 13 Aug 2026 09:26:03 -0600
+
 system76-firmware (1.0.77) noble; urgency=medium
 
   * Allow firmware switching for gaze20

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ const MODEL_WHITELIST: &[&str] = &[
     "thelio-mira-r3",
     "thelio-mira-r4",
     "thelio-mira-r5",
+    "thelio-mira-r6",
     "thelio-r1",
     "thelio-r2",
     "thelio-r3",


### PR DESCRIPTION
I noticed some version bumps when adding models. Not everyone does it, so I'm not sure if it's actually needed. If a version bump is okay, should I add details of the few commits between the 1.0.77 release and this proposed 1.0.78 release?

Otherwise, I can change this PR back to only include the model addition to `src/lib.rs`.